### PR TITLE
[문법, 단어 수정] getting-started.mdx

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -198,7 +198,7 @@ T> 프로덕션 번들에 번들로 제공될 패키지를 설치할 때 `npm in
  </html>
 ```
 
-이 설정에서 `index.js`는 명시적으로 `lodash`가 있어야 하며, 이것을 `_`에 바인딩합니다.(글로벌 스코프의 오염 없음) 모듈에 필요한 의존성을 명시함으로써 webpack은 이 정보를 사용하여 디펜던시 그래프를 만들 수 있습니다. 그런 다음 그래프를 사용하여 스크립트가 올바른 순서로 실행되는 최적화된 번들을 생성합니다.
+이 설정에서 `index.js`는 명시적으로 `lodash`가 있어야 하며, 이것을 `_`에 바인딩합니다.(전역 스코프의 오염 없음) 모듈에 필요한 의존성을 명시함으로써 webpack은 이 정보를 사용하여 디펜던시 그래프를 만들 수 있습니다. 그런 다음 그래프를 사용하여 스크립트가 올바른 순서로 실행되는 최적화된 번들을 생성합니다.
 
 그럼 `npx webpack`을 실행해 보겠습니다. 이 스크립트는 `src/index.js`를 [엔트리 포인트](/concepts/entry-points)로 사용하고 [output](/concepts/output)으로 `dist/main.js`을 생성합니다. `npx` 명령어는 Node 8.2/npm 5.2.0 이상 버전에서 제공되며, 처음에 설치했던 webpack 패키지의 webpack 바이너리(`./node_modules/.bin/webpack`)를 실행합니다.
 
@@ -268,7 +268,7 @@ cacheable modules 530 KiB
 webpack 5.4.0 compiled successfully in 1934 ms
 ```
 
-T> `webpack.config.js`가 있으면 `webpack` 명령은 기본으로 이것을 선택합니다. 여기서는 `--config` 옵션을 사용하여 어떠한 이름의 설정이던 사용할 수 있도록 합니다. 이것은 여러 개의 파일로 분할해야 하는 복잡한 설정에서 유용합니다.
+T> `webpack.config.js`가 있으면 `webpack` 명령은 기본으로 이것을 선택합니다. 여기서는 `--config` 옵션을 사용하여 어떠한 이름의 설정이든 사용할 수 있도록 합니다. 이것은 여러 개의 파일로 분할해야 하는 복잡한 설정에서 유용합니다.
 
 설정 파일은 단순한 CLI 사용보다 훨씬 많은 유연성을 제공합니다. 로더의 규칙, 플러그인, 해석 옵션 및 기타 여러 향상된 기능을 지정할 수 있습니다. 더 자세한 것은 [설정 문서](/configuration)를 참고하세요.
 
@@ -344,4 +344,4 @@ T> npm 5+ 이상을 사용하는 경우에는 디렉터리에 `package-lock.json
 
 W> 신뢰할 수 없는 코드는 webpack으로 컴파일하지 마세요. 이로 인해 컴퓨터, 원격 서버 또는 애플리케이션 최종 사용자의 웹 브라우저에서 악성 코드가 실행될 수 있습니다.
 
-webpack 디자인에 대해 자세히 알아보고 싶으면 [basic concepts](/concepts)과 [configuration](/configuration) 페이지를 확인하세요. 또한 [API](/api)에서 webpack이 제공하는 다양한 인터페이스를 자세히 살펴봅니다.
+Webpack 디자인에 대해 자세히 알아보고 싶으면 [basic concepts](/concepts)과 [configuration](/configuration) 페이지를 확인하세요. 또한 [API](/api)에서 webpack이 제공하는 다양한 인터페이스를 자세히 살펴봅니다.


### PR DESCRIPTION
## Summary 

https://github.com/line/webpack.kr/issues/475

## 리뷰 참고 사항

line 201 : glossary를 반영하여 글로벌 스코프 -> 전역 스코프 수정
line 271 : 문법 수정(던 -> 든)  (던 : 과거의 경험, 든 : '-든지' 의 준말)
line 347 : webpack -> Webpack 수정 (문장 맨 앞의 webpack은 대문자 반영)
