### PR TITLE
오탈자 수정 configuration/index.mdx

### DIFF
--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -50,7 +50,7 @@ T> webpack을 처음 사용하시나요? 시작하려면 webpack의 [핵심 개�
 
 W> 이 설정에서는 Node의 내장 [path module](https://nodejs.org/api/path.html)을 사용하고 앞에 [\_\_dirname](https://nodejs.org/docs/latest/api/globals.html#globals_dirname) 전역을 추가합니다. 이를 통해 운영 체제 간의 파일 경로 문제를 방지하고 상대 경로를 예상대로 작동하도록 합니다. POSIX와 Windows 경로에 대한 자세한 내용은 [이 섹션](https://nodejs.org/api/path.html#path_windows_vs_posix)을 참조하세요.
 
-W> 많은 배열 설정에서` "..."`를 통해 기본값을 참조할 수 있습니다.
+W> 많은 배열 설정에서 `"..."`를 통해 기본값을 참조할 수 있습니다.
 
 **webpack.config.js**
 


### PR DESCRIPTION
## Summary 

#486 

## 리뷰 참고 사항

마크다운 범위가 띄어쓰기 포함해서 잘못 지정되어있어서 해당 부분 수정했습니다.
` "..."` -> `"..."`
## Glossary

