### PR TITLE
번역 누락 configuration/watch.mdx

### DIFF
--- a/src/content/configuration/watch.mdx
+++ b/src/content/configuration/watch.mdx
@@ -146,10 +146,10 @@ T> 만약 감시 기능이 작동하지 않는다면, 이 옵션을 사용해 �
 
 ### watchOptions.followSymlinks
 
-Follow symbolic links while looking for a file. This is usually not needed as webpack already resolves symlinks with [`resolve.symlinks`](/configuration/resolve/#resolvesymlinks).
+파일을 찾는 동안 심볼릭 링크를 따라갑니다. webpack이 이미 `resolve.symlinks`를 사용하여 심볼릭 링크를 해석했으므로 대개 이 작업이 필요하지는 않습니다.
 
-- Type: `boolean`
-- Example:
+- 타입: `boolean`
+- 예시는 다음과 같습니다.
   ```js
   module.exports = {
     //...

--- a/src/content/configuration/watch.mdx
+++ b/src/content/configuration/watch.mdx
@@ -146,7 +146,7 @@ T> 만약 감시 기능이 작동하지 않는다면, 이 옵션을 사용해 �
 
 ### watchOptions.followSymlinks
 
-파일을 찾는 동안 심볼릭 링크를 따라갑니다. webpack이 이미 `resolve.symlinks`를 사용하여 심볼릭 링크를 해석했으므로 대개 이 작업이 필요하지는 않습니다.
+파일을 찾는 동안 심볼릭 링크를 따라갑니다. webpack이 이미 [`resolve.symlinks`](/configuration/resolve/#resolvesymlinks)를 사용하여 심볼릭 링크를 해석했으므로 대개 이 작업이 필요하지는 않습니다.
 
 - 타입: `boolean`
 - 예시는 다음과 같습니다.


### PR DESCRIPTION
## Summary 

#498 

## 리뷰 참고 사항

watchOptions.followSymlinks 부분 번역이 누락되어있어서 해당 부분 번역했습니다.

## Glossary

type: 타입
symbolic links: 심볼릭 링크
example: -> 예시는 다음과 같습니다.
