### PR TITLE
[오역 수정] define-plugin.mdx

### DIFF
--- a/src/content/plugins/define-plugin.mdx
+++ b/src/content/plugins/define-plugin.mdx
@@ -47,7 +47,7 @@ console.log('Running App version ' + VERSION);
 if (!BROWSER_SUPPORTS_HTML5) require('html5shiv');
 ```
 
-W> `process`의 값을 정의할 때 `process: { env: { NODE_ENV: JSON.stringify('production') } }` 보다 `'process.env.NODE_ENV': JSON.stringify('production')`를 선호합니다. 만약 후자의 방식을 사용하면 process 객체를 덮어쓰게 되므로 `process` 객체에 다른 값이 정의될 것으로 예상되는 일부 모듈과의 호환성이 깨질 수 있습니다.
+W> `process`의 값을 정의할 때 `process: { env: { NODE_ENV: JSON.stringify('production') } }` 보다 `'process.env.NODE_ENV': JSON.stringify('production')`를 선호합니다. 만약 전자의 방식을 사용하면 process 객체를 덮어쓰게 되므로 `process` 객체에 다른 값이 정의될 것으로 예상되는 일부 모듈과의 호환성이 깨질 수 있습니다.
 
 T> 플러그인은 텍스트에 직접 수정 작업을 진행하기 때문에 주어진 값은 반드시 문자열 자체에 **실제 따옴표**를 포함해야 합니다. 일반적으로 이것은 `'"production"'`과 같은 대체 따옴표를 사용하거나 `JSON.stringify('production')`를 사용하여 수행됩니다.
 


### PR DESCRIPTION
## Summary 

resolve https://github.com/line/webpack.kr/issues/1233

> Using the latter will overwrite the process object which can break compatibility with some modules that expect other values on the process object to be defined.~

원문은 `latter(후자)`가 맞긴 하나, 한글로 번역된 문장에서 헷갈릴 여지가 있어보여 `후자 -> 전자` 로 수정을 제안 해봅니다 :)

~[컨트리뷰팅 문서](https://github.com/line/webpack.kr/blob/kr/CONTRIBUTING_UNIVERSAL.md#%EB%B3%80%EA%B2%BD-%EC%A0%9C%EC%95%88)를 뒤늦게 확인해서 본 피알은 close 후 해당 문서에 적혀있는것처럼 이슈로 제보 하겠습니다 🙇~


## 리뷰 참고 사항

## Glossary
